### PR TITLE
new formatting mode, attachment

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,7 +21,27 @@ workflows:
         - webhook_url: $SLACK_WEBHOOK_URL
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
-        - message: First, On Success test
+        - formatting_mode: "attachment"
+        - message: |
+            First, On Success test - attachment formatting mode
+
+            Multiline, with a link: https://www.bitrise.io ,
+            and _some_ *highlight*
+        - color: good
+    - path::./:
+        title: On Success
+        is_skippable: false
+        inputs:
+        - webhook_url: $SLACK_WEBHOOK_URL
+        - channel: $SLACK_CHANNEL
+        - from_username: step-dev-test
+        - formatting_mode: "text"
+        - message: |
+            First, On Success test - text formatting mode
+
+            Multiline, with a link: https://www.bitrise.io ,
+            and _some_ *highlight*
+        - color: good
     - path::./:
         title: On Success - without channel
         is_skippable: false
@@ -30,6 +50,7 @@ workflows:
         - channel: ''
         - from_username: step-dev-test
         - message: On Success test - without channel param
+        - color: warning
     - path::./:
         title: On Success
         description: |-
@@ -43,6 +64,7 @@ workflows:
         - emoji: ":white_check_mark:"
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - is_debug_mode: "yes"
+        - color: "#00ff00"
 
   missing-webhook-url-test:
     steps:

--- a/main.go
+++ b/main.go
@@ -95,9 +95,13 @@ func (configs ConfigsModel) validate() error {
 	if configs.Color == "" {
 		return errors.New("No Color parameter specified!")
 	}
-	if configs.FormattingMode == "" {
+
+	switch configs.FormattingMode {
+	case formattingModeText, formattingModeAttachment:
+		// allowed/accepted
+	case "":
 		return errors.New("No FormattingMode parameter specified!")
-	} else if configs.FormattingMode != formattingModeText && configs.FormattingMode != formattingModeAttachment {
+	default:
 		return fmt.Errorf("Invalid FormattingMode: %s", configs.FormattingMode)
 	}
 	return nil

--- a/step.yml
+++ b/step.yml
@@ -22,9 +22,11 @@ type_tags:
 is_requires_admin_user: false
 is_always_run: true
 is_skippable: true
-dependencies:
-  - manager: brew
-    name: go
+deps:
+  brew:
+  - name: go
+  apt_get:
+  - name: golang
 toolkit:
   go:
     package_name: github.com/bitrise-io/steps-slack-message

--- a/step.yml
+++ b/step.yml
@@ -70,6 +70,44 @@ inputs:
         leave this option empty then the default one will be used.
       is_expand: true
       is_required: false
+  - formatting_mode: "attachment"
+    opts:
+      title: "Formatting mode"
+      description: |
+        The formatting mode to use.
+
+        Slack can present the message
+        as a markdown-ish `text`, with the formatting you can
+        use in the Slack client when you chat, or can accept it
+        as an `attachment`.
+
+        The `attachment` mode supports coloring but does not
+        support the regular highlighting format, like `*bold*`
+        or `_italic_`.
+      is_expand: true
+      is_required: true
+      value_options:
+      - attachment
+      - text
+  - color: "good"
+    opts:
+      title: "Message color"
+      description: |
+        Color of the message. You can use hex color codes,
+        or the predefined Slack color words like `good`, `warning` or `danger`.
+
+        You can find more info about the color and other text formatting
+        in [Slack's documentation](https://api.slack.com/docs/message-attachments).
+      is_expand: true
+      is_required: true
+  - color_on_error: "danger"
+    opts:
+      title: "Message color"
+      description: |
+        **This option will be used if the build failed.** If you
+        leave this option empty then the default one will be used.
+      is_expand: true
+      is_required: false
   - emoji: ":white_check_mark:"
     opts:
       title: "Emoji Icon"


### PR DESCRIPTION
formatting mode can now be set, to either attachment of text

attachment allows a color for the message border, but does not allow the standard text formatting shortcuts

text mode is what was used before, which is the exact same thing what a user can type into Slack, with the formatting options included