### PR TITLE
Feature: add image urls to slack attachment messages

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,6 +51,20 @@ workflows:
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - is_debug_mode: "yes"
         - color: "#00ff00"
+    - path::./:
+        title: On Success - 
+        is_skippable: false
+        inputs:
+        - webhook_url: $SLACK_WEBHOOK_URL
+        - channel: $SLACK_CHANNEL
+        - from_username: step-dev-test
+        - message: |
+            On Success test - with an image
+
+            Multiline, with a link: https://www.bitrise.io ,
+            and _some_ *highlight*
+        - color: good
+        - image_url: https://media.giphy.com/media/l2YWfJ8WCq1zWgFyw/giphy.gif
 
   missing-webhook-url-test:
     steps:

--- a/main.go
+++ b/main.go
@@ -47,8 +47,8 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		EmojiOnError:        os.Getenv("emoji_on_error"),
 		Color:               os.Getenv("color"),
 		ColorOnError:        os.Getenv("color_on_error"),
-		ImageURL             os.Getenv("image_url"),
-		ImageURLOnError      os.Getenv("image_url_on_error"),
+		ImageURL:            os.Getenv("image_url"),
+		ImageURLOnError:     os.Getenv("image_url_on_error"),
 		IconURL:             os.Getenv("icon_url"),
 		IconURLOnError:      os.Getenv("icon_url_on_error"),
 		//

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ type ConfigsModel struct {
 	MessageOnError      string
 	Color               string
 	ColorOnError        string
+	ImageURL            string
+	ImageURLOnError     string
 	Emoji               string
 	EmojiOnError        string
 	IconURL             string
@@ -45,6 +47,8 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		EmojiOnError:        os.Getenv("emoji_on_error"),
 		Color:               os.Getenv("color"),
 		ColorOnError:        os.Getenv("color_on_error"),
+		ImageURL             os.Getenv("image_url"),
+		ImageURLOnError      os.Getenv("image_url_on_error"),
 		IconURL:             os.Getenv("icon_url"),
 		IconURLOnError:      os.Getenv("icon_url_on_error"),
 		//
@@ -65,6 +69,8 @@ func (configs ConfigsModel) print() {
 	fmt.Println(" - MessageOnError:", configs.MessageOnError)
 	fmt.Println(" - Color:", configs.Color)
 	fmt.Println(" - ColorOnError:", configs.ColorOnError)
+	fmt.Println(" - ImageURL:", configs.ImageURL)
+	fmt.Println(" - ImageURLOnError:", configs.ImageURLOnError)
 	fmt.Println(" - Emoji:", configs.Emoji)
 	fmt.Println(" - EmojiOnError:", configs.EmojiOnError)
 	fmt.Println(" - IconURL:", configs.IconURL)
@@ -96,6 +102,7 @@ type AttachmentItemModel struct {
 	Fallback string   `json:"fallback"`
 	Text     string   `json:"text"`
 	Color    string   `json:"color,omitempty"`
+	ImageURL string   `json:"image_url"`
 	MrkdwnIn []string `json:"mrkdwn_in,omitempty"`
 }
 
@@ -132,11 +139,21 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 		}
 	}
 
+	msgImage := configs.ImageURL
+	if configs.IsBuildFailed {
+		if configs.ImageURLOnError == "" {
+			fmt.Println(colorstring.Yellow("(i) Build failed but no image_url_on_error defined, using default."))
+		} else {
+			msgImage = configs.ImageURLOnError
+		}
+	}
+
 	reqParams := RequestParams{
 		Attachments: []AttachmentItemModel{
 			{
 				Text: msgText, Fallback: msgText,
 				Color:    msgColor,
+				ImageURL: msgImage,
 				MrkdwnIn: []string{"text", "pretext", "fields"},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 			msgText = configs.MessageOnError
 		}
 	}
-
+	// - optional attachment params
 	msgImage := configs.ImageURL
 	if configs.IsBuildFailed {
 		if configs.ImageURLOnError == "" {

--- a/step.yml
+++ b/step.yml
@@ -96,17 +96,17 @@ inputs:
     opts:
       title: "Image URL"
       description: |
-      Optionally you can specify a Image to displayed within your message. 
-      This image will be rendered within the message. 
+        Optionally you can specify a Image to displayed within your message. 
+        This image will be rendered within the message. 
       is_expand: true
       is_required: false 
   - image_url_on_error:
     opts:
       title: "Image URL"
       description: |
-       **This option will be used if the build failed.** 
-      Optionally you can specify a Image to displayed within your message. 
-      This image will be rendered within the message. 
+        **This option will be used if the build failed.** 
+        Optionally you can specify a Image to displayed within your message. 
+        This image will be rendered within the message. 
       is_expand: true
       is_required: false    
   - emoji: ":white_check_mark:"

--- a/step.yml
+++ b/step.yml
@@ -96,8 +96,8 @@ inputs:
     opts:
       title: "Image URL"
       description: |
-        Optionally you can specify a Image to displayed within your message. 
-        This image will be rendered within the message. 
+        Optionally render an image from a URL. 
+        You can include GIFs. 
       is_expand: true
       is_required: false 
   - image_url_on_error:
@@ -105,8 +105,8 @@ inputs:
       title: "Image URL"
       description: |
         **This option will be used if the build failed.** 
-        Optionally you can specify a Image to displayed within your message. 
-        This image will be rendered within the message. 
+        Optionally render an image from a URL. 
+        You can include GIFs. 
       is_expand: true
       is_required: false    
   - emoji: ":white_check_mark:"

--- a/step.yml
+++ b/step.yml
@@ -92,6 +92,23 @@ inputs:
         leave this option empty then the default one will be used.
       is_expand: true
       is_required: false
+  - image_url:
+    opts:
+      title: "Image URL"
+      description: |
+      Optionally you can specify a Image to displayed within your message. 
+      This image will be rendered within the message. 
+      is_expand: true
+      is_required: false 
+  - image_url_on_error:
+    opts:
+      title: "Image URL"
+      description: |
+       **This option will be used if the build failed.** 
+      Optionally you can specify a Image to displayed within your message. 
+      This image will be rendered within the message. 
+      is_expand: true
+      is_required: false    
   - emoji: ":white_check_mark:"
     opts:
       title: "Emoji Icon"


### PR DESCRIPTION
addressing issue #11 
Images will now be rendered within the attachment message within slack. 
Ability to set an onError image. 
This is an optional parameter.  