### PR TITLE
Add option for Linkifying user name and channel name

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -102,11 +102,13 @@ workflows:
         - webhook_url: $SLACK_WEBHOOK_URL
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
+        - link_names: "yes"
         - message: |
             First, On Success test
 
             Multiline, with a link: https://www.bitrise.io ,
-            and _some_ *highlight*
+            _some_ *highlight*,
+            and linkify @slackbot #random
         - color: good
     - path::./:
         title: On Success - without channel

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type ConfigsModel struct {
 	EmojiOnError        string
 	IconURL             string
 	IconURLOnError      string
+	IsLinkNamesOn       bool
 	// Other Inputs
 	IsDebugMode bool
 	// Other configs
@@ -53,6 +54,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		ImageURLOnError:     os.Getenv("image_url_on_error"),
 		IconURL:             os.Getenv("icon_url"),
 		IconURLOnError:      os.Getenv("icon_url_on_error"),
+		IsLinkNamesOn:       os.Getenv("link_names") == "yes",
 		//
 		IsDebugMode: (os.Getenv("is_debug_mode") == "yes"),
 		//
@@ -77,6 +79,7 @@ func (configs ConfigsModel) print() {
 	fmt.Println(" - EmojiOnError:", configs.EmojiOnError)
 	fmt.Println(" - IconURL:", configs.IconURL)
 	fmt.Println(" - IconURLOnError:", configs.IconURLOnError)
+	fmt.Println(" - IsLinkNamesOn:", configs.IsLinkNamesOn)
 	fmt.Println("")
 	fmt.Println(colorstring.Blue("Other configs:"))
 	fmt.Println(" - IsDebugMode:", configs.IsDebugMode)
@@ -119,6 +122,7 @@ type RequestParams struct {
 	Username  *string `json:"username"`
 	EmojiIcon *string `json:"icon_emoji"`
 	IconURL   *string `json:"icon_url"`
+	LinkNames int     `json:"link_names"`
 }
 
 // ensureNewlineEscapeChar replaces the "\" + "n" char sequences with the "\n" newline char
@@ -210,6 +214,10 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 	// if Icon URL defined ignore the emoji input
 	if reqParams.IconURL != nil {
 		reqParams.EmojiIcon = nil
+	}
+
+	if configs.IsLinkNamesOn {
+		reqParams.LinkNames = 1
 	}
 
 	if configs.IsDebugMode {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ type ConfigsModel struct {
 	EmojiOnError        string
 	IconURL             string
 	IconURLOnError      string
-	IsLinkNamesOn       bool
+	IsLinkNames         bool
 	// Other Inputs
 	IsDebugMode bool
 	// Other configs
@@ -54,7 +54,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		ImageURLOnError:     os.Getenv("image_url_on_error"),
 		IconURL:             os.Getenv("icon_url"),
 		IconURLOnError:      os.Getenv("icon_url_on_error"),
-		IsLinkNamesOn:       os.Getenv("link_names") == "yes",
+		IsLinkNames:         os.Getenv("link_names") == "yes",
 		//
 		IsDebugMode: (os.Getenv("is_debug_mode") == "yes"),
 		//
@@ -79,7 +79,7 @@ func (configs ConfigsModel) print() {
 	fmt.Println(" - EmojiOnError:", configs.EmojiOnError)
 	fmt.Println(" - IconURL:", configs.IconURL)
 	fmt.Println(" - IconURLOnError:", configs.IconURLOnError)
-	fmt.Println(" - IsLinkNamesOn:", configs.IsLinkNamesOn)
+	fmt.Println(" - IsLinkNames:", configs.IsLinkNames)
 	fmt.Println("")
 	fmt.Println(colorstring.Blue("Other configs:"))
 	fmt.Println(" - IsDebugMode:", configs.IsDebugMode)
@@ -216,7 +216,7 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 		reqParams.EmojiIcon = nil
 	}
 
-	if configs.IsLinkNamesOn {
+	if configs.IsLinkNames {
 		reqParams.LinkNames = 1
 	}
 

--- a/step.yml
+++ b/step.yml
@@ -155,7 +155,7 @@ inputs:
     opts:
       title: "Link Names"
       description: |
-        Link names such as @username
+        Linkify names in the message such as `@slackbot` or `#random`
       is_expand: true
       is_required: false
       value_options:

--- a/step.yml
+++ b/step.yml
@@ -151,7 +151,7 @@ inputs:
         leave this option empty then the default one will be used.
       is_expand: true
       is_required: false
-  - link_names: "no"
+  - link_names: "yes"
     opts:
       title: "Link Names"
       description: |

--- a/step.yml
+++ b/step.yml
@@ -151,6 +151,16 @@ inputs:
         leave this option empty then the default one will be used.
       is_expand: true
       is_required: false
+  - link_names: "no"
+    opts:
+      title: "Link Names"
+      description: |
+        Link names such as @username
+      is_expand: true
+      is_required: false
+      value_options:
+      - "yes"
+      - "no"
   - is_debug_mode: "no"
     opts:
       title: "Debug mode?"


### PR DESCRIPTION
Hi! Thanks for the great service! I added a small feature to slack message step. 

# Done in this PR
- Added option to the step to linkify user name and channel name when posted from slack bot 

<img width="406" alt="screen shot 2017-08-01 at 22 54 52" src="https://user-images.githubusercontent.com/6277118/28859576-0493ab54-770d-11e7-8fa6-85c6a0910bf1.png">


this is related issue #13 