### PR TITLE
Send plain text, not in attachments

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -119,6 +119,7 @@ workflows:
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
         - link_names: "yes"
+        - text: On Success test
         - message: |
             First, On Success test
 
@@ -179,3 +180,13 @@ workflows:
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
         - message: $SLACK_MESSAGE_FROM_SCRIPT
+    - path::./:
+        title: Should send plain text
+        is_skippable: false
+        inputs:
+        - webhook_url: $SLACK_WEBHOOK_URL
+        - channel: $SLACK_CHANNEL
+        - from_username: step-dev-test
+        - text: plain text
+        - message: |
+            On Success Test - with plain text

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -119,7 +119,6 @@ workflows:
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
         - link_names: "yes"
-        - text: On Success test
         - message: |
             First, On Success test
 
@@ -187,6 +186,10 @@ workflows:
         - webhook_url: $SLACK_WEBHOOK_URL
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
-        - text: plain text
+        - message_type: plain
         - message: |
-            On Success Test - with plain text
+            On Success Test - send plain text
+
+            Multiline, with a link: https://www.bitrise.io ,
+            _some_ *highlight*,
+            and linkify @slackbot #random

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type ConfigsModel struct {
 	Channel             string
 	FromUsername        string
 	FromUsernameOnError string
+	Text                string
 	Message             string
 	MessageOnError      string
 	Color               string
@@ -44,6 +45,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		Channel:             os.Getenv("channel"),
 		FromUsername:        os.Getenv("from_username"),
 		FromUsernameOnError: os.Getenv("from_username_on_error"),
+		Text:                os.Getenv("text"),
 		Message:             os.Getenv("message"),
 		MessageOnError:      os.Getenv("message_on_error"),
 		Emoji:               os.Getenv("emoji"),
@@ -69,6 +71,7 @@ func (configs ConfigsModel) print() {
 	fmt.Println(" - Channel:", configs.Channel)
 	fmt.Println(" - FromUsername:", configs.FromUsername)
 	fmt.Println(" - FromUsernameOnError:", configs.FromUsernameOnError)
+	fmt.Println(" - Text:", configs.Text)
 	fmt.Println(" - Message:", configs.Message)
 	fmt.Println(" - MessageOnError:", configs.MessageOnError)
 	fmt.Println(" - Color:", configs.Color)
@@ -188,6 +191,10 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 		}
 	}
 
+	reqText := configs.Text
+	if reqText != "" {
+		reqParams.Text = reqText
+	}
 	reqEmojiIcon := configs.Emoji
 	if reqEmojiIcon != "" {
 		reqParams.EmojiIcon = &reqEmojiIcon

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ type ConfigsModel struct {
 	Channel             string
 	FromUsername        string
 	FromUsernameOnError string
-	Text                string
 	Message             string
 	MessageOnError      string
 	Color               string
@@ -33,6 +32,7 @@ type ConfigsModel struct {
 	IconURL             string
 	IconURLOnError      string
 	IsLinkNames         bool
+	MessageType		    string
 	// Other Inputs
 	IsDebugMode bool
 	// Other configs
@@ -45,7 +45,6 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		Channel:             os.Getenv("channel"),
 		FromUsername:        os.Getenv("from_username"),
 		FromUsernameOnError: os.Getenv("from_username_on_error"),
-		Text:                os.Getenv("text"),
 		Message:             os.Getenv("message"),
 		MessageOnError:      os.Getenv("message_on_error"),
 		Emoji:               os.Getenv("emoji"),
@@ -57,6 +56,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		IconURL:             os.Getenv("icon_url"),
 		IconURLOnError:      os.Getenv("icon_url_on_error"),
 		IsLinkNames:         os.Getenv("link_names") == "yes",
+		MessageType:		 os.Getenv("message_type"),
 		//
 		IsDebugMode: (os.Getenv("is_debug_mode") == "yes"),
 		//
@@ -71,7 +71,6 @@ func (configs ConfigsModel) print() {
 	fmt.Println(" - Channel:", configs.Channel)
 	fmt.Println(" - FromUsername:", configs.FromUsername)
 	fmt.Println(" - FromUsernameOnError:", configs.FromUsernameOnError)
-	fmt.Println(" - Text:", configs.Text)
 	fmt.Println(" - Message:", configs.Message)
 	fmt.Println(" - MessageOnError:", configs.MessageOnError)
 	fmt.Println(" - Color:", configs.Color)
@@ -83,6 +82,7 @@ func (configs ConfigsModel) print() {
 	fmt.Println(" - IconURL:", configs.IconURL)
 	fmt.Println(" - IconURLOnError:", configs.IconURLOnError)
 	fmt.Println(" - IsLinkNames:", configs.IsLinkNames)
+	fmt.Println(" - MessageType:", configs.MessageType)
 	fmt.Println("")
 	fmt.Println(colorstring.Blue("Other configs:"))
 	fmt.Println(" - IsDebugMode:", configs.IsDebugMode)
@@ -163,15 +163,19 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 		}
 	}
 
-	reqParams := RequestParams{
-		Attachments: []AttachmentItemModel{
+	reqParams := RequestParams{}
+
+	if configs.MessageType == "rich" {
+		reqParams.Attachments = []AttachmentItemModel{
 			{
 				Text: msgText, Fallback: msgText,
 				Color:    msgColor,
 				ImageURL: msgImage,
 				MrkdwnIn: []string{"text", "pretext", "fields"},
 			},
-		},
+		}
+	} else {
+		reqParams.Text = msgText
 	}
 
 	// - optional
@@ -191,10 +195,6 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 		}
 	}
 
-	reqText := configs.Text
-	if reqText != "" {
-		reqParams.Text = reqText
-	}
 	reqEmojiIcon := configs.Emoji
 	if reqEmojiIcon != "" {
 		reqParams.EmojiIcon = &reqEmojiIcon

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type ConfigsModel struct {
 	IconURL             string
 	IconURLOnError      string
 	IsLinkNames         bool
-	MessageType		    string
+	MessageType         string
 	// Other Inputs
 	IsDebugMode bool
 	// Other configs
@@ -56,7 +56,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		IconURL:             os.Getenv("icon_url"),
 		IconURLOnError:      os.Getenv("icon_url_on_error"),
 		IsLinkNames:         os.Getenv("link_names") == "yes",
-		MessageType:		 os.Getenv("message_type"),
+		MessageType:         os.Getenv("message_type"),
 		//
 		IsDebugMode: (os.Getenv("is_debug_mode") == "yes"),
 		//

--- a/main.go
+++ b/main.go
@@ -165,7 +165,9 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 
 	reqParams := RequestParams{}
 
-	if configs.MessageType == "rich" {
+	if configs.MessageType == "plain" {
+		reqParams.Text = msgText
+	} else {
 		reqParams.Attachments = []AttachmentItemModel{
 			{
 				Text: msgText, Fallback: msgText,
@@ -174,8 +176,6 @@ func CreatePayloadParam(configs ConfigsModel) (string, error) {
 				MrkdwnIn: []string{"text", "pretext", "fields"},
 			},
 		}
-	} else {
-		reqParams.Text = msgText
 	}
 
 	// - optional

--- a/step.yml
+++ b/step.yml
@@ -60,11 +60,6 @@ inputs:
         leave this option empty then the default one will be used.
       is_expand: true
       is_required: false
-  - text:
-    opts:
-      title: "The plain text you want to send"
-      is_expand: true
-      is_required: false
   - message: |-
       *Build succeeded on ${BITRISE_GIT_BRANCH}!* :tada:
 
@@ -98,6 +93,8 @@ inputs:
 
         You can find more info about the color and other text formatting
         in [Slack's documentation](https://api.slack.com/docs/message-attachments).
+
+        **If message type is plain, this option will be ignored!**
       is_expand: true
       is_required: true
   - color_on_error: "danger"
@@ -106,6 +103,8 @@ inputs:
       description: |
         **This option will be used if the build failed.** If you
         leave this option empty then the default one will be used.
+
+        **If message type is plain, this option will be ignored!**
       is_expand: true
       is_required: false
   - image_url:
@@ -114,6 +113,8 @@ inputs:
       description: |
         Optionally render an image from a URL.
         You can include GIFs.
+
+        **If message type is plain, this option will be ignored!**
       is_expand: true
       is_required: false
   - image_url_on_error:
@@ -123,6 +124,8 @@ inputs:
         **This option will be used if the build failed.**
         Optionally render an image from a URL.
         You can include GIFs.
+
+        **If message type is plain, this option will be ignored!**
       is_expand: true
       is_required: false
   - emoji: ":white_check_mark:"
@@ -177,6 +180,16 @@ inputs:
       value_options:
       - "yes"
       - "no"
+  - message_type: "rich"
+    opts:
+      title: "Message Type"
+      description: |
+        Send not-colored message without images if this option is plain.
+      is_expand: true
+      is_required: false
+      value_options:
+      - "rich"
+      - "plain"
   - is_debug_mode: "no"
     opts:
       title: "Debug mode?"

--- a/step.yml
+++ b/step.yml
@@ -60,6 +60,11 @@ inputs:
         leave this option empty then the default one will be used.
       is_expand: true
       is_required: false
+  - text:
+    opts:
+      title: "The plain text you want to send"
+      is_expand: true
+      is_required: false
   - message: |-
       *Build succeeded on ${BITRISE_GIT_BRANCH}!* :tada:
 

--- a/step.yml
+++ b/step.yml
@@ -186,7 +186,7 @@ inputs:
       description: |
         Send not-colored message without images if this option is plain.
       is_expand: true
-      is_required: false
+      is_required: true
       value_options:
       - "rich"
       - "plain"


### PR DESCRIPTION
This is releated issue https://github.com/bitrise-io/steps-slack-message/issues/29 .
Sending plain text is optional.

This is the result of `bitrise run test`.
First and last post has plain text.
![image](https://user-images.githubusercontent.com/10195648/35845672-c70f4be2-0b56-11e8-848e-5595bd55be47.png)
