### PR TITLE
PostMessage; Add api-token support.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,6 +19,7 @@ workflows:
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
+        - api_token: $SLACK_API_TOKEN
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
         - link_names: "yes"
@@ -34,6 +35,7 @@ workflows:
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
+        - api_token: $SLACK_API_TOKEN
         - channel: ""
         - from_username: step-dev-test
         - message: On Success test - without channel param
@@ -44,6 +46,7 @@ workflows:
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
+        - api_token: $SLACK_API_TOKEN
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test-2
         - message: The Icon URL should be used instead of the Emoji input!
@@ -56,6 +59,7 @@ workflows:
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
+        - api_token: $SLACK_API_TOKEN
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
         - message: |
@@ -79,6 +83,7 @@ workflows:
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
+        - api_token: $SLACK_API_TOKEN
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
         - message: $SLACK_MESSAGE_FROM_SCRIPT
@@ -93,6 +98,7 @@ workflows:
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
+        - api_token: $SLACK_API_TOKEN
         - channel: $SLACK_CHANNEL
         - from_username_on_error: step-dev-test-ON-ERROR
         - message: On Error TEST
@@ -102,6 +108,7 @@ workflows:
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
+        - api_token: $SLACK_API_TOKEN
         - channel: no-channel-like-this
   missing-webhook-url-test:
     steps:

--- a/step.yml
+++ b/step.yml
@@ -5,7 +5,7 @@ description: |
   Send a [Slack](https://slack.com/) message to a channel or group.
 
   You have to register an **Incoming WebHook integration** at:
-  https://**YOURTEAMNAME**.slack.com/services
+  https://**YOURTEAMNAME**.slack.com/services or create a bot with an API token
 
   On the WebHook integration's page copy the **Webhook URL**.
 
@@ -43,13 +43,16 @@ inputs:
       - "no"
 
 # Message inputs
-
   - webhook_url:
     opts:
-      title: "Slack Webhook URL"
-      is_required: true
+      title: "Slack Webhook URL (Webhook or API token is required)"
+      is_required: false
       is_sensitive: true
-
+  - api_token: 
+    opts:
+      title: "Slack API token (Webhook or API token is required)"
+      is_required: false
+      is_sensitive: true
   - channel:
     opts:
       title: "Target Slack channel, group or username"


### PR DESCRIPTION
User can choose between Webhook URL or API token
API info; https://api.slack.com/methods/chat.postMessage